### PR TITLE
fix: 更换暂存目录至 MODDIR/tmp，避免 /data/local/tmp 被系统清空

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -436,7 +436,7 @@ echo_log() {
 	fi
 }
 kill_Serve() {
-    local LOCK_DIR="/data/local/tmp/.backup_lock"
+    local LOCK_DIR="$MODDIR/tmp/.backup_lock"
     local MY_PID="$$"
 
     # 使用 mkdir 作為原子鎖操作，避免 TOCTOU 競態條件


### PR DESCRIPTION
## 变更内容

将脚本的临时目录从 `/data/local/tmp` 改为 `$MODDIR/tmp`，避免 `/data/local/tmp` 被系统清空导致脚本运行异常。

### 具体修改
- `tools/tools.sh:353` — `TMPDIR="/data/local/tmp"` → `TMPDIR="$MODDIR/tmp"`
- `tools/tools.sh:439` — `LOCK_DIR` 改为 `$TMPDIR/.backup_lock`，跟随 TMPDIR 变更
- `tools/tools.sh:357` — chown 失败时静默忽略（新路径下非必需）