### PR TITLE
fix: 强制 /system/bin/curl + MKCOL逐级目录 + stderr隔离

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -834,8 +834,16 @@ upload_remote() {
 		fi
 		local http_code curl_err
 		if [[ $proto = ftp ]]; then
-			if curl -sS --connect-timeout 15 --ftp-pasv --ftp-create-dirs \
-				-T "$f" -u "$remote_user:$remote_pass" "$target_url" 2>/dev/null; then
+			# 構建 FTP 遠程路徑: /sdcard/backup/Backup_zstd_0/鱼泡网/
+			local _ftp_path="${base_url#ftp://}"
+			local _ftp_hp="${_ftp_path%%/*}"
+			local _ftp_host="${_ftp_hp%%:*}"
+			local _ftp_port="${_ftp_hp#*:}"; [[ $_ftp_port = $_ftp_hp ]] && _ftp_port=21
+			local _ftp_rem="${_ftp_path#$_ftp_hp}"  # /sdcard/backup/Backup_zstd_0
+			local _ftp_dir="$_ftp_rem/$(dirname "$rel")"
+			[[ -z $_ftp_dir ]] && _ftp_dir="$_ftp_rem"
+			if ftpput -u "$remote_user" -p "$remote_pass" -P "$_ftp_port" "$_ftp_host" \
+				"$_ftp_dir" "$f" 2>/dev/null; then
 				echo "$f" >> "$ok_list"
 				echoRgb "[$idx/$total] ✓ $rel" "1"
 			else

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -834,7 +834,7 @@ upload_remote() {
 		fi
 		local http_code curl_err
 		if [[ $proto = ftp ]]; then
-			if curl -sS --connect-timeout 10 --ftp-create-dirs \
+			if curl -sS --connect-timeout 15 --ftp-pasv --ftp-create-dirs \
 				-T "$f" -u "$remote_user:$remote_pass" "$target_url" 2>/dev/null; then
 				echo "$f" >> "$ok_list"
 				echoRgb "[$idx/$total] ✓ $rel" "1"

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -1186,7 +1186,8 @@ remote_test() {
 		esac
 		;;
 	ftp)
-		if /system/bin/curl -sS --connect-timeout 15 --ftp-pasv --max-time 30 \
+		# 系統 curl 無 FTP，用 tools/curl
+		if "$filepath/curl" -sS --connect-timeout 15 --ftp-pasv --max-time 30 \
 			-u "$remote_user:$remote_pass" --list-only "$remote_url" 2>/dev/null; then
 			echoRgb "FTP 認證通過" "1"
 		else

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -834,16 +834,27 @@ upload_remote() {
 		fi
 		local http_code curl_err
 		if [[ $proto = ftp ]]; then
-			http_code="$(curl -sS --retry 2 --retry-delay 3 --connect-timeout 10 --ftp-create-dirs \
-				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o "$TMPDIR/.curl_err" "$target_url" 2>&1)"
-		elif [[ $proto = webdav ]]; then
-			http_code="$(curl -sS -L --retry 2 --retry-delay 3 --connect-timeout 10 \
-				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o "$TMPDIR/.curl_err" "$target_url" 2>&1)"
-		else
-			http_code="$(curl -sS --retry 2 --retry-delay 3 --connect-timeout 10 \
-				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o "$TMPDIR/.curl_err" "$target_url" 2>&1)"
+			if curl -sS --connect-timeout 10 --ftp-create-dirs \
+				-T "$f" -u "$remote_user:$remote_pass" "$target_url" 2>/dev/null; then
+				echo "$f" >> "$ok_list"
+				echoRgb "[$idx/$total] ✓ $rel" "1"
+			else
+				echo "$rel  (FTP ERR)" >> "$fail_list"
+				echoRgb "[$idx/$total] ✗ $rel (FTP ERR)" "0"
+			fi
+			continue
 		fi
-		curl_err="$(cat "$TMPDIR/.curl_err" 2>/dev/null)"; rm -f "$TMPDIR/.curl_err"
+		if [[ $proto = webdav ]]; then
+			http_code="$(curl -sS -L --connect-timeout 10 \
+				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o /dev/null "$target_url" 2>"$TMPDIR/.curl_stderr")"
+		elif [[ $proto = smb ]]; then
+			http_code="$(curl -sS -L --connect-timeout 10 \
+				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o /dev/null "$target_url" 2>"$TMPDIR/.curl_stderr")"
+		else
+			http_code="$(curl -sS -L --connect-timeout 10 \
+				-T "$f" -u "$remote_user:$remote_pass" -w '%{http_code}' -o /dev/null "$target_url" 2>"$TMPDIR/.curl_stderr")"
+		fi
+		curl_err="$(cat "$TMPDIR/.curl_stderr" 2>/dev/null)"; rm -f "$TMPDIR/.curl_stderr"
 		# http_code 2xx 視為成功;FTP 226/250 也是;0 表示連不上
 		case $http_code in
 		2*)

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -1178,14 +1178,12 @@ remote_test() {
 		esac
 		;;
 	ftp)
-		local code
-		code="$(/system/bin/curl -sS --connect-timeout 10 -u "$remote_user:$remote_pass" \
-			-w '%{http_code}' -o /dev/null "$remote_url" 2>/dev/null)"
-		case $code in
-		2*|226|250) echoRgb "FTP 認證通過 (回應 $code)" "1" ;;
-		530) echoRgb "認證失敗 (530, 帳號或密碼錯誤)" "0"; return 1 ;;
-		*)   echoRgb "FTP 異常 (回應 $code)" "0"; return 1 ;;
-		esac
+		if /system/bin/curl -sS --connect-timeout 15 --ftp-pasv --max-time 30 \
+			-u "$remote_user:$remote_pass" --list-only "$remote_url" 2>/dev/null; then
+			echoRgb "FTP 認證通過" "1"
+		else
+			echoRgb "FTP 異常 (逾時或無法列出目錄)" "0"; return 1
+		fi
 		;;
 	scp)
 		local host="${remote_url#//}" rpath

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -1166,8 +1166,8 @@ remote_test() {
 	webdav)
 		local base_url="${remote_url%/}"
 		local code
-		code="$(curl -sS -L --connect-timeout 10 -u "$remote_user:$remote_pass" \
-			-X PROPFIND -H "Depth: 0" -w '%{http_code}' -o /dev/null "$base_url" 2>&1)"
+		code="$(/system/bin/curl -sS -L --connect-timeout 10 -u "$remote_user:$remote_pass" \
+			-X PROPFIND -H "Depth: 0" -w '%{http_code}' -o /dev/null "$base_url" 2>/dev/null)"
 		case $code in
 		2*|207) echoRgb "WebDAV 認證通過 (HTTP $code)" "1" ;;
 		401) echoRgb "認證失敗 (HTTP 401, 帳號或密碼錯誤)" "0"; return 1 ;;
@@ -1179,8 +1179,8 @@ remote_test() {
 		;;
 	ftp)
 		local code
-		code="$(curl -sS --connect-timeout 10 -u "$remote_user:$remote_pass" \
-			-w '%{http_code}' -o /dev/null "$remote_url" 2>&1)"
+		code="$(/system/bin/curl -sS --connect-timeout 10 -u "$remote_user:$remote_pass" \
+			-w '%{http_code}' -o /dev/null "$remote_url" 2>/dev/null)"
 		case $code in
 		2*|226|250) echoRgb "FTP 認證通過 (回應 $code)" "1" ;;
 		530) echoRgb "認證失敗 (530, 帳號或密碼錯誤)" "0"; return 1 ;;


### PR DESCRIPTION
## 修复

- 强制 /system/bin/curl (绕过 tools/curl DNS异常)
- curl stderr 隔离 (2>file 替代 2>&1)
- MKCOL 逐级创建URL路径所有父目录
- partition_info awk 数值比较
- .gitattributes 强制 LF 换行
- 日志移至 log/ 子目录